### PR TITLE
fix: use .ts as main on package.json and ignore dist files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 .DS_Store
 /test-results
 test-results.json
+/dist

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "indent-list-reporter",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Playwright list reporter for terminal with colors and indentation'",
-  "main": "./dist/src/indent-list-reporter.js",
+  "main": "./src/indent-list-reporter.ts",
   "type": "module",
   "homepage": "https://github.com/syzzana/indent-list-reporter/blob/main/README.md",
   "scripts": {


### PR DESCRIPTION
Direct usage to .ts files only on package.json. Soon will find a solution about js too.